### PR TITLE
chore(config): stop confusion between cli and agent mutual configs

### DIFF
--- a/cmd/client/cds.go
+++ b/cmd/client/cds.go
@@ -64,8 +64,13 @@ type cmd interface {
 }
 
 func main() {
+	dbSrc, err := config.DBSource()
+	if err != nil {
+		clog.Error("Failed to resolve state database source", err)
+		os.Exit(1)
+	}
 
-	if err := db.Load(config.DBSource()); err != nil {
+	if err := db.Load(dbSrc); err != nil {
 		clog.Error("Failed to load state from database", err)
 		os.Exit(1)
 	}

--- a/internal/bootstrap/boot.go
+++ b/internal/bootstrap/boot.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"net"
 
+	"github.com/amadeusitgroup/cds/internal/cerr"
 	"github.com/amadeusitgroup/cds/internal/clog"
 	"github.com/amadeusitgroup/cds/internal/config"
 	cg "github.com/amadeusitgroup/cds/internal/global"
@@ -12,7 +13,11 @@ import (
 
 func StartAgent(hostname string) error {
 	// check if agent is already running
-	if isAgentRunning(hostname) {
+	running, err := isAgentRunning(hostname)
+	if err != nil {
+		return cerr.AppendErrorFmt("failed to check for agent running on %s", err, hostname)
+	}
+	if running {
 		clog.Debug("Agent is already running")
 		return StartOnRunError{}
 	}
@@ -23,17 +28,23 @@ func StartAgent(hostname string) error {
 
 }
 
-func isAgentRunning(hostName string) bool {
-	server := config.AgentAddress(hostName)
+func isAgentRunning(hostName string) (bool, error) {
+	server, err := config.AgentAddress(hostName)
+	if err != nil {
+		return false, cerr.AppendError("failed to resolve agent address", err)
+	}
+	if server == cg.EmptyStr {
+		return false, nil
+	}
 	conn, err := net.Dial("tcp", server)
 	if err != nil {
 		clog.Debug("Failed to connect to agent", err)
-		return false
+		return false, nil
 	}
 	defer func() {
 		_ = conn.Close()
 	}()
-	return true
+	return true, nil
 }
 
 func fireRemote(hostName string) error {

--- a/internal/bootstrap/boot_darwin.go
+++ b/internal/bootstrap/boot_darwin.go
@@ -45,16 +45,16 @@ func fire() error {
 		return cerr.AppendError("Failed to parse agent address", parseErr)
 	}
 
-	if err := config.AddClientToConfig(config.NewClient(
+	if err := config.AddAgentToConfig(config.NewAgent(
 		config.WithTargetAddress(addr.String()),
-		config.WithClientTLS(
+		config.WithAgentTLS(
 			config.NewTlssecret(
 				config.WithCA(cdstls.CAFilePath),
 				config.WithCert(cdstls.ClientCertFilePath),
 				config.WithKey(cdstls.ClientKeyFilePath)),
 		),
 	)); err != nil {
-		return cerr.AppendError("failed to add client to CLI config", err)
+		return cerr.AppendError("failed to add agent to CLI config", err)
 	}
 	return nil
 }

--- a/internal/config/agent.go
+++ b/internal/config/agent.go
@@ -1,56 +1,119 @@
 package config
 
 import (
+	"bytes"
+
 	"github.com/amadeusitgroup/cds/internal/cenv"
 	"github.com/amadeusitgroup/cds/internal/cerr"
 	cg "github.com/amadeusitgroup/cds/internal/global"
 	"github.com/amadeusitgroup/cds/internal/source"
+	"gopkg.in/yaml.v3"
 )
 
 const (
 	kAgentFileName string = "aconfig.yaml"
 )
 
+// agentClientData is the typed representation of aconfig.yaml content.
+// This config is owned by the agent and tracks the clients registered against it.
+type agentClientData struct {
+	APIVersion string   `yaml:"apiVersion"`
+	Clients    []client `yaml:"clients"`
+}
+
 func InitAgentConfig() error {
-	agentPath := cenv.ConfigFile(kAgentFileName)
-
-	src, err := source.NewLocalSource(agentPath)
-	if err != nil {
-		return cerr.AppendError("failed to create agent config source", err)
-	}
-
-	if err := EnsureSourceWithDefault(src, defaultAgentConfig(), cg.KPermFile); err != nil {
-		return cerr.AppendError("failed to ensure agent config exists", err)
+	if _, err := agentConfigSource(); err != nil {
+		return err
 	}
 
 	return nil
 }
 
-// var (
-// 	agents []agent
-// )
+// RegisteredClients returns the clients currently loaded from aconfig.yaml.
+func RegisteredClients() ([]client, error) {
+	data, err := readAgentData()
+	if err != nil {
+		return nil, err
+	}
 
-type agent struct {
-	Server string    `yaml:"server"` // server address
-	Certs  tlssecret `yaml:"tls"`
+	copied := make([]client, len(data.Clients))
+	copy(copied, data.Clients)
+	return copied, nil
 }
 
-func NewAgent(options ...func(*agent)) agent {
-	agent := agent{}
+// AddClientToConfig appends a client entry to the agent config and persists the change back to the stored source.
+func AddClientToConfig(c client) error {
+	data, err := readAgentData()
+	if err != nil {
+		return err
+	}
+	data.Clients = append(data.Clients, c)
+	return writeAgentData(data)
+}
+
+func readAgentData() (agentClientData, error) {
+	src, err := agentConfigSource()
+	if err != nil {
+		return agentClientData{}, err
+	}
+	r, err := src.Read()
+	if err != nil {
+		return agentClientData{}, cerr.AppendError("failed to read agent config", err)
+	}
+	var d agentClientData
+	if err := yaml.NewDecoder(r).Decode(&d); err != nil {
+		return agentClientData{}, cerr.AppendError("failed to parse agent config", err)
+	}
+	return d, nil
+}
+
+func writeAgentData(d agentClientData) error {
+	src, err := agentConfigSource()
+	if err != nil {
+		return err
+	}
+	if d.APIVersion == cg.EmptyStr {
+		d.APIVersion = "v1"
+	}
+	out, err := yaml.Marshal(d)
+	if err != nil {
+		return cerr.AppendError("failed to serialize agent config", err)
+	}
+	return src.Write(bytes.NewReader(out), cg.KPermFile)
+}
+
+type client struct {
+	Name  string    `yaml:"name"`
+	Certs tlssecret `yaml:"tls"`
+}
+
+func NewClient(options ...func(*client)) client {
+	c := client{}
 	for _, option := range options {
-		option(&agent)
+		option(&c)
 	}
-	return agent
+	return c
 }
 
-func WithAddress(addr string) func(*agent) {
-	return func(a *agent) {
-		a.Server = addr
+func WithClientName(name string) func(*client) {
+	return func(c *client) {
+		c.Name = name
 	}
 }
 
-func WithServerTLS(t tlssecret) func(*agent) {
-	return func(c *agent) {
+func WithClientTLS(t tlssecret) func(*client) {
+	return func(c *client) {
 		c.Certs = t
 	}
+}
+
+func agentConfigSource() (source.Source, error) {
+	src, err := source.NewLocalSource(cenv.ConfigFile(kAgentFileName))
+	if err != nil {
+		return nil, cerr.AppendError("failed to create agent config source", err)
+	}
+	if err := EnsureSourceWithDefault(src, defaultAgentConfig(), cg.KPermFile); err != nil {
+		return nil, cerr.AppendError("failed to ensure agent config exists", err)
+	}
+	return src, nil
 }

--- a/internal/config/agent_test.go
+++ b/internal/config/agent_test.go
@@ -1,0 +1,59 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/amadeusitgroup/cds/internal/cos"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitAgentConfigCreatesClientsRegistry(t *testing.T) {
+	setupConfigTestFS(t)
+
+	require.NoError(t, InitAgentConfig())
+
+	content, err := cos.ReadFile("/tmp/testconfig/.xcds/aconfig.yaml")
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "clients:")
+	assert.NotContains(t, string(content), "agents:")
+}
+
+func TestAddClientToConfigPersistsClientsWithoutInit(t *testing.T) {
+	setupConfigTestFS(t)
+
+	require.NoError(t, AddClientToConfig(NewClient(
+		WithClientName("my-laptop"),
+		WithClientTLS(NewTlssecret(
+			WithCA("/tmp/ca.pem"),
+			WithCert("/tmp/client.pem"),
+			WithKey("/tmp/client-key.pem"),
+		)),
+	)))
+
+	data, err := readAgentData()
+	require.NoError(t, err)
+	require.Len(t, data.Clients, 1)
+	assert.Equal(t, "my-laptop", data.Clients[0].Name)
+	assert.Equal(t, "/tmp/client.pem", data.Clients[0].Certs.Cert)
+}
+
+func TestRegisteredClientsLoadsClientsWithoutInit(t *testing.T) {
+	setupConfigTestFS(t)
+
+	require.NoError(t, cos.Fs.MkdirAll("/tmp/testconfig/.xcds", 0755))
+	require.NoError(t, cos.WriteFile("/tmp/testconfig/.xcds/aconfig.yaml", []byte(`apiVersion: v1
+clients:
+  - name: my-laptop
+    tls:
+      ca: /tmp/ca.pem
+      certificate: /tmp/client.pem
+      key: /tmp/client-key.pem
+`), 0600))
+
+	clients, err := RegisteredClients()
+	require.NoError(t, err)
+	require.Len(t, clients, 1)
+	assert.Equal(t, "my-laptop", clients[0].Name)
+	assert.Equal(t, "/tmp/client.pem", clients[0].Certs.Cert)
+}

--- a/internal/config/cli.go
+++ b/internal/config/cli.go
@@ -9,58 +9,47 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-var (
-	clients []client
-)
-
 // cliAgentData is the typed representation of cliconfig.yaml content.
+// This config is owned by the CLI and tracks the user's registered agents.
 type cliAgentData struct {
-	APIVersion string   `yaml:"apiVersion"`
-	Clients    []client `yaml:"agents"`
+	APIVersion string  `yaml:"apiVersion"`
+	Agents     []agent `yaml:"agents"`
 }
 
-// ReloadCLIConfig re-reads the CLI agent config from the stored source
-// and refreshes the in-memory client list.
-func ReloadCLIConfig() error {
-	if cliSource == nil {
-		return cerr.NewError("config source has not been initialized")
-	}
-	data, err := readCLIAgentData()
-	if err != nil {
-		return cerr.AppendError("failed to reload CLI config", err)
-	}
-	clients = data.Clients
-	return nil
-}
-
-// AddClientToConfig appends a client entry to the CLI agent config and persists the change back to the stored source.
-func AddClientToConfig(c client) error {
-	if cliSource == nil {
-		return cerr.NewError("config.Init has not been called")
-	}
+// AddAgentToConfig appends an agent entry to the CLI config and persists the change back to the stored source.
+func AddAgentToConfig(a agent) error {
 	data, err := readCLIAgentData()
 	if err != nil {
 		return err
 	}
-	data.Clients = append(data.Clients, c)
+	data.Agents = append(data.Agents, a)
 	return writeCLIAgentData(data)
 }
 
 // AgentAddress returns the gRPC address for the agent running on hostname.
-func AgentAddress(hostname string) string {
-	for _, c := range clients {
-		if strings.Contains(c.TargetSrv, hostname) {
-			return c.TargetSrv
+func AgentAddress(hostname string) (string, error) {
+	data, err := readCLIAgentData()
+	if err != nil {
+		return cg.EmptyStr, err
+	}
+
+	for _, agent := range data.Agents {
+		if strings.Contains(agent.TargetSrv, hostname) {
+			return agent.TargetSrv, nil
 		}
 	}
 	if hostname == cg.KLocalhost {
-		return ":8087"
+		return ":8087", nil
 	}
-	return cg.EmptyStr
+	return cg.EmptyStr, nil
 }
 
 func readCLIAgentData() (cliAgentData, error) {
-	r, err := cliSource.Read()
+	src, err := cliConfigSource()
+	if err != nil {
+		return cliAgentData{}, err
+	}
+	r, err := src.Read()
 	if err != nil {
 		return cliAgentData{}, cerr.AppendError("failed to read CLI agent config", err)
 	}
@@ -72,41 +61,48 @@ func readCLIAgentData() (cliAgentData, error) {
 }
 
 func writeCLIAgentData(d cliAgentData) error {
+	src, err := cliConfigSource()
+	if err != nil {
+		return err
+	}
+	if d.APIVersion == cg.EmptyStr {
+		d.APIVersion = "v1"
+	}
 	out, err := yaml.Marshal(d)
 	if err != nil {
 		return cerr.AppendError("failed to serialize CLI agent config", err)
 	}
-	return cliSource.Write(bytes.NewReader(out), cg.KPermFile)
+	return src.Write(bytes.NewReader(out), cg.KPermFile)
 }
 
-type client struct {
+type agent struct {
 	Certs     tlssecret `yaml:"tls"`
 	SshTunnel bool      `yaml:"ssh-tunnel"`   // special case of ssh tunnel
 	TargetSrv string    `yaml:"targetServer"` // server address
 }
 
-func NewClient(options ...func(*client)) client {
-	c := client{}
+func NewAgent(options ...func(*agent)) agent {
+	a := agent{}
 	for _, option := range options {
-		option(&c)
+		option(&a)
 	}
-	return c
+	return a
 }
 
-func WithClientTLS(t tlssecret) func(*client) {
-	return func(c *client) {
-		c.Certs = t
-	}
-}
-
-func WithSSHTunnel(use bool) func(*client) {
-	return func(c *client) {
-		c.SshTunnel = use
+func WithAgentTLS(t tlssecret) func(*agent) {
+	return func(a *agent) {
+		a.Certs = t
 	}
 }
 
-func WithTargetAddress(addr string) func(*client) {
-	return func(a *client) {
+func WithSSHTunnel(use bool) func(*agent) {
+	return func(a *agent) {
+		a.SshTunnel = use
+	}
+}
+
+func WithTargetAddress(addr string) func(*agent) {
+	return func(a *agent) {
 		a.TargetSrv = addr
 	}
 }

--- a/internal/config/cli_test.go
+++ b/internal/config/cli_test.go
@@ -1,0 +1,47 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/amadeusitgroup/cds/internal/cos"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAgentAddressLoadsRegisteredAgentsWithoutInit(t *testing.T) {
+	setupConfigTestFS(t)
+
+	require.NoError(t, cos.Fs.MkdirAll("/tmp/testconfig/.xcds", 0755))
+	require.NoError(t, cos.WriteFile("/tmp/testconfig/.xcds/cliconfig.yaml", []byte(`apiVersion: v1
+agents:
+  - targetServer: https://agent.example:8443
+`), 0600))
+
+	address, err := AgentAddress("agent.example")
+	require.NoError(t, err)
+	assert.Equal(t, "https://agent.example:8443", address)
+}
+
+func TestAddAgentToConfigPersistsAgentsWithoutInit(t *testing.T) {
+	setupConfigTestFS(t)
+
+	require.NoError(t, AddAgentToConfig(NewAgent(
+		WithTargetAddress("https://agent.example:8443"),
+		WithSSHTunnel(true),
+		WithAgentTLS(NewTlssecret(
+			WithCA("/tmp/ca.pem"),
+			WithCert("/tmp/client.pem"),
+			WithKey("/tmp/client-key.pem"),
+		)),
+	)))
+
+	data, err := readCLIAgentData()
+	require.NoError(t, err)
+	require.Len(t, data.Agents, 1)
+	assert.Equal(t, "https://agent.example:8443", data.Agents[0].TargetSrv)
+	assert.True(t, data.Agents[0].SshTunnel)
+	assert.Equal(t, "/tmp/ca.pem", data.Agents[0].Certs.CA)
+	address, err := AgentAddress("agent.example")
+	require.NoError(t, err)
+	assert.Equal(t, "https://agent.example:8443", address)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,35 +40,22 @@ func WithKey(key string) func(*tlssecret) {
 // cliconfig.yaml example:
 // apiVersion: v1
 // agents:
-//   - agent:
-//     certificate-authority-data: HJHJHJHJHJHJHJH
-//     client-key-data: CHGHSGSHSGHSGHS
-//     server: https://localhost:8087
-//   - agent:
-//     certificate-authority-data: HJHJHJHJHJHJHJH
-//     client-key-data: CHGHSGSHSGHSGHS
-//     server: https://my.server.fix.me:1337
-//   - agent:
-//     server: http://localhost:1337
-//     ssh: yes
+//   - targetServer: https://localhost:8087
+//     tls:
+//       ca: /Users/me/.xcds/certs/ca.pem
+//       certificate: /Users/me/.xcds/certs/client.pem
+//       key: /Users/me/.xcds/certs/client-key.pem
+//   - targetServer: localhost:1337
+//     ssh-tunnel: true
 
 // aconfig.yaml example:
 // apiVersion: v1
-// client:
-//   certificate-authority-data: HJHJHJHJHJHJHJH
-//   client-key-data: CHGHSGSHSGHSGHS
-// agents:
-//   - agent:
-//     certificate-authority-data: HJHJHJHJHJHJHJH
-//     client-key-data: CHGHSGSHSGHSGHS
-//     server: https://localhost:8087
-//   - agent:
-//     certificate-authority-data: HJHJHJHJHJHJHJH
-//     client-key-data: CHGHSGSHSGHSGHS
-//     server: https://my.server.fix.me:1337
-//   - agent:
-//     server: http://localhost:1337
-//     ssh: yes
+// clients:
+//   - name: my-laptop
+//     tls:
+//       ca: /Users/me/.xcds/certs/ca.pem
+//       certificate: /Users/me/.xcds/certs/client.pem
+//       key: /Users/me/.xcds/certs/client-key.pem
 
 // defaultCLIAgentConfig returns the default content for cliconfig.yaml.
 func defaultCLIAgentConfig() io.Reader {
@@ -80,7 +67,6 @@ agents:
 // defaultAgentConfig returns the default content for aconfig.yaml.
 func defaultAgentConfig() io.Reader {
 	return strings.NewReader(`apiVersion: v1
-client:
-agents:
+clients:
 `)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,18 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/amadeusitgroup/cds/internal/cos"
+	"github.com/spf13/afero"
+)
+
+func setupConfigTestFS(t *testing.T) {
+	t.Helper()
+
+	cos.Fs = afero.NewMemMapFs()
+	t.Setenv("CDS_CONFIG_PATH", "/tmp/testconfig")
+	t.Cleanup(func() {
+		cos.SetRealFileSystem()
+	})
+}

--- a/internal/config/manifest.go
+++ b/internal/config/manifest.go
@@ -25,12 +25,6 @@ const (
 	kManifestFileName = "cdsconfig.yaml"
 )
 
-var (
-	cliSource  source.Source
-	profSource source.Source
-	dbSource   source.Source
-)
-
 type SourceRef struct {
 	Type string `yaml:"type"`
 	Ref  string `yaml:"ref"`
@@ -43,47 +37,31 @@ type Manifest struct {
 }
 
 func InitCLIConfig() error {
-	loadedManifest, err := LoadManifest()
-	if err != nil {
-		return cerr.AppendError("failed to load manifest", err)
+	if _, err := cliConfigSource(); err != nil {
+		return err
 	}
-
-	cliSource, err = loadedManifest.Resolve(SourceKeyCLIAgentConfig)
-	if err != nil {
-		return cerr.AppendError("failed to resolve CLI agent config source", err)
+	if _, err := profileSource(); err != nil {
+		return err
 	}
-	if err := EnsureSourceWithDefault(cliSource, defaultCLIAgentConfig(), cg.KPermFile); err != nil {
-		return cerr.AppendError("failed to ensure CLI agent config exists", err)
+	if _, err := DBSource(); err != nil {
+		return err
 	}
-
-	profSource, err = loadedManifest.Resolve(SourceKeyProfile)
-	if err != nil {
-		return cerr.AppendError("failed to resolve profile source", err)
-	}
-
-	dbSource, err = loadedManifest.Resolve(SourceKeyDB)
-	if err != nil {
-		return cerr.AppendError("failed to resolve db source", err)
-	}
-	if err := EnsureSourceWithDefault(dbSource, strings.NewReader("{}"), cg.KPermFile); err != nil {
-		return cerr.AppendError("failed to ensure db file exists", err)
-	}
-
 	return nil
 }
 
 func ProfileReader() (io.Reader, error) {
-	if profSource == nil {
-		return nil, cerr.NewError("config.Init has not been called")
+	src, err := profileSource()
+	if err != nil {
+		return nil, err
 	}
-	return profSource.Read()
+	return src.Read()
 }
 
 // DBSource returns the resolved source for the state database.
 // The db package accepts source.Source directly so callers can pass
 // the return value through without importing source themselves.
-func DBSource() source.Source {
-	return dbSource
+func DBSource() (source.Source, error) {
+	return dbSource()
 }
 
 func LoadManifest() (Manifest, error) {
@@ -154,6 +132,48 @@ func EnsureSourceWithDefault(src source.Source, defaultContent io.Reader, perm o
 	}
 
 	return src.Write(defaultContent, perm)
+}
+
+func cliConfigSource() (source.Source, error) {
+	src, err := manifestSource(SourceKeyCLIAgentConfig)
+	if err != nil {
+		return nil, cerr.AppendError("failed to resolve CLI agent config source", err)
+	}
+	if err := EnsureSourceWithDefault(src, defaultCLIAgentConfig(), cg.KPermFile); err != nil {
+		return nil, cerr.AppendError("failed to ensure CLI agent config exists", err)
+	}
+	return src, nil
+}
+
+func profileSource() (source.Source, error) {
+	src, err := manifestSource(SourceKeyProfile)
+	if err != nil {
+		return nil, cerr.AppendError("failed to resolve profile source", err)
+	}
+	return src, nil
+}
+
+func dbSource() (source.Source, error) {
+	src, err := manifestSource(SourceKeyDB)
+	if err != nil {
+		return nil, cerr.AppendError("failed to resolve db source", err)
+	}
+	if err := EnsureSourceWithDefault(src, strings.NewReader("{}"), cg.KPermFile); err != nil {
+		return nil, cerr.AppendError("failed to ensure db file exists", err)
+	}
+	return src, nil
+}
+
+func manifestSource(key string) (source.Source, error) {
+	loadedManifest, err := LoadManifest()
+	if err != nil {
+		return nil, cerr.AppendError("failed to load manifest", err)
+	}
+	src, err := loadedManifest.Resolve(key)
+	if err != nil {
+		return nil, err
+	}
+	return src, nil
 }
 
 func defaultManifest() Manifest {

--- a/internal/config/manifest_test.go
+++ b/internal/config/manifest_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"io"
 	"strings"
 	"testing"
 
@@ -195,4 +196,43 @@ func TestEnsureSourceWithDefault_Exists(t *testing.T) {
 	data, err := cos.ReadFile("/tmp/existing.yaml")
 	require.NoError(t, err)
 	assert.Equal(t, "existing", string(data))
+}
+
+func TestProfileReader_ResolvesWithoutInit(t *testing.T) {
+	cos.Fs = afero.NewMemMapFs()
+	defer cos.SetRealFileSystem()
+
+	t.Setenv("CDS_CONFIG_PATH", "/tmp/testconfig")
+
+	err := cos.Fs.MkdirAll("/tmp/testconfig/.xcds", 0755)
+	require.NoError(t, err)
+	err = cos.WriteFile("/tmp/testconfig/.xcds/profile.json", []byte(`{"name":"default"}`), 0600)
+	require.NoError(t, err)
+
+	r, err := ProfileReader()
+	require.NoError(t, err)
+
+	content, err := io.ReadAll(r)
+	require.NoError(t, err)
+	assert.Equal(t, `{"name":"default"}`, string(content))
+}
+
+func TestDBSource_ResolvesWithoutInit(t *testing.T) {
+	cos.Fs = afero.NewMemMapFs()
+	defer cos.SetRealFileSystem()
+
+	t.Setenv("CDS_CONFIG_PATH", "/tmp/testconfig")
+
+	src, err := DBSource()
+	require.NoError(t, err)
+
+	exists, err := src.Exists()
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	r, err := src.Read()
+	require.NoError(t, err)
+	content, err := io.ReadAll(r)
+	require.NoError(t, err)
+	assert.Equal(t, "{}", string(content))
 }


### PR DESCRIPTION
## Summary

Client and agent logic were confused. I initiated the choice that the filename will be the owner of the config (agent owns agent.go config, same for cli)
Added documentation of that on the type.

## Related issues

- Fixes #
- Closes #
- Relates-to #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / maintenance

## How to test

Provide the commands and steps used to validate this change.

```bash
make test
make lint
```

## Checklist

- [ ] I ran `make test` (or equivalent) and it passed.
- [ ] I ran `make lint` (if applicable) and it passed.
- [ ] I updated docs (README/CONTRIBUTING) if needed.
- [ ] I added or updated tests where appropriate.
- [ ] I linked relevant issues and provided context.

## Notes for reviewers

Anything you want reviewers to pay attention to (risk areas, rollout, follow-ups).
