### PR TITLE
feat: Initialize a final pretty output package

### DIFF
--- a/internal/command/cds.go
+++ b/internal/command/cds.go
@@ -1,12 +1,18 @@
 package command
 
 import (
-	"github.com/spf13/cobra"
+	"strings"
+
+	"github.com/amadeusitgroup/cds/internal/cerr"
 	"github.com/amadeusitgroup/cds/internal/clog"
+	"github.com/amadeusitgroup/cds/internal/output"
+	"github.com/spf13/cobra"
 )
 
 type cds struct {
-	verbose bool
+	verbose    bool
+	outputFlag string // --output: "json", "text", "auto"
+	quiet      bool   // --quiet: suppress all output
 	defaultCmd
 }
 
@@ -18,6 +24,8 @@ type cds struct {
 
 func (c *cds) initFlags() {
 	c.cmd.PersistentFlags().BoolVarP(&c.verbose, "verbose", "v", false, "Verbose output, switches log level to Debug")
+	c.cmd.PersistentFlags().StringVarP(&c.outputFlag, "output", "o", "auto", `Output format: "auto", "json", "text"`)
+	c.cmd.PersistentFlags().BoolVarP(&c.quiet, "quiet", "q", false, "Suppress all output; exit code signals success or failure")
 }
 
 func (c *cds) initSubCommands() {
@@ -46,6 +54,13 @@ containers orchestration platform.`,
 				if c.verbose {
 					clog.Verbose()
 				}
+				cmdPath := strings.TrimPrefix(cmd.CommandPath(), "cds ")
+				preparedCmd := strings.ReplaceAll(cmdPath, " ", ".")
+				octx, err := output.NewOutputOptions(output.WithDetect(c.outputFlag, c.quiet, c.verbose), output.WithCommand(preparedCmd))
+				if err != nil {
+					return cerr.AppendError("There was an error initializing output options", err)
+				}
+				cmd.SetContext(output.WithOutputOptions(cmd.Context(), octx))
 				return nil
 			},
 		}

--- a/internal/output/mode.go
+++ b/internal/output/mode.go
@@ -1,0 +1,34 @@
+package output
+
+// Mode represents the output rendering strategy for a CLI invocation.
+type Mode int
+
+const (
+	// ModeInteractive renders rich terminal output: pterm spinners, tables, colors.
+	ModeInteractive Mode = iota
+	// ModePlain renders human-readable text without ANSI escape codes or spinners.
+	ModePlain
+	// ModeJSON renders structured JSON output (auto-detected when stdout is not a TTY).
+	ModeJSON
+	// ModeQuiet suppresses all output; only the exit code conveys the result.
+	ModeQuiet
+	// ModeUnknown is used when an invalid mode is specified.
+	ModeUnknown
+)
+
+func (m Mode) String() string {
+	switch m {
+	case ModeInteractive:
+		return "interactive"
+	case ModePlain:
+		return "plain"
+	case ModeJSON:
+		return "json"
+	case ModeQuiet:
+		return "quiet"
+	case ModeUnknown:
+		return "unknown"
+	default:
+		return "unknown"
+	}
+}

--- a/internal/output/model.go
+++ b/internal/output/model.go
@@ -1,0 +1,164 @@
+package output
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/amadeusitgroup/cds/internal/cerr"
+	"github.com/mattn/go-isatty"
+	"golang.org/x/term"
+)
+
+type OutputOptions struct {
+	mode      Mode
+	writer    io.Writer
+	errWriter io.Writer // default: os.Stderr
+	width     int       // terminal width, 0 if unknown
+	noColor   bool
+	verbose   bool
+	command   string // dot-separated command path (e.g. "project.list")
+}
+
+type renderer interface {
+	// HumanReadable returns the prepared string describing the data
+	HumanReadable(o OutputOptions) string
+	// MachineReadable returns a fully loaded object ready to be Marshalled
+	MachineReadable() any
+}
+
+func renderJSON(o OutputOptions, r renderer) error {
+	enc := json.NewEncoder(o.writer)
+	enc.SetIndent("", "\t")
+	return enc.Encode(map[string]any{"data": r.MachineReadable()})
+}
+
+func renderHuman(o OutputOptions, r renderer) error {
+	result := r.HumanReadable(o)
+	_, err := fmt.Fprint(o.writer, result)
+	return err
+}
+
+func Render(o OutputOptions, r renderer) error {
+	switch o.mode {
+	case ModeQuiet:
+		return nil
+	case ModeJSON:
+		return renderJSON(o, r)
+	case ModeInteractive, ModePlain:
+		return renderHuman(o, r)
+	default:
+		return cerr.NewError(fmt.Sprintf("invalid mode given to render: %s", o.mode))
+	}
+}
+
+type outputOptionsKey struct{}
+
+// WithOutputOptions stores an output outputOptions in a context.Context.
+func WithOutputOptions(ctx context.Context, octx *OutputOptions) context.Context {
+	if octx == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, outputOptionsKey{}, octx)
+}
+
+type outputTransformers func(*OutputOptions)
+
+func WithDetect(outputFlag string, quiet bool, verbose bool) outputTransformers {
+	return func(oOpts *OutputOptions) {
+		oOpts.verbose = verbose
+		// Detect terminal width
+		if w, _, err := term.GetSize(int(os.Stdout.Fd())); err == nil {
+			oOpts.width = w
+		}
+
+		// Detect color capability
+		oOpts.noColor = isNoColorSet() || !isColorable()
+
+		// Determine mode (priority order)
+		switch {
+		case quiet:
+			oOpts.mode = ModeQuiet
+		case resolveOutputFlag(outputFlag) == "json":
+			oOpts.mode = ModeJSON
+		case resolveOutputFlag(outputFlag) == "text":
+			if oOpts.noColor {
+				oOpts.mode = ModePlain
+			} else {
+				oOpts.mode = ModeInteractive
+			}
+		case !isColorable():
+			// Auto-detect: non-TTY → JSON
+			oOpts.mode = ModeJSON
+		case oOpts.noColor:
+			oOpts.mode = ModePlain
+		default:
+			oOpts.mode = ModeUnknown
+		}
+	}
+}
+
+func WithCommand(cmd string) outputTransformers {
+	return func(oOpts *OutputOptions) {
+		oOpts.command = cmd
+	}
+}
+
+func NewOutputOptions(o ...outputTransformers) (*OutputOptions, error) {
+	oOpts := &OutputOptions{
+		writer:    os.Stdout,
+		errWriter: os.Stderr,
+	}
+	for _, transformer := range o {
+		transformer(oOpts)
+	}
+
+	if oOpts.mode == ModeUnknown {
+		return nil, cerr.NewError(fmt.Sprintf("invalid output mode detected for command '%s'", oOpts.command))
+	}
+
+	return oOpts, nil
+}
+
+// FromContext retrieves the output outputOptions from a context.Context.
+// Returns a sensible default if none is set.
+func FromContext(ctx context.Context) OutputOptions {
+	if ctx != nil {
+		switch octx := ctx.Value(outputOptionsKey{}).(type) {
+		case OutputOptions:
+			return octx
+		case *OutputOptions:
+			if octx != nil {
+				return *octx
+			}
+		}
+	}
+	return OutputOptions{
+		mode:      ModeInteractive,
+		writer:    os.Stdout,
+		errWriter: os.Stderr,
+	}
+}
+
+// resolveOutputFlag checks the --output flag and CDS_OUTPUT env var.
+func resolveOutputFlag(flag string) string {
+	if flag != "" {
+		return strings.ToLower(flag)
+	}
+	if env, ok := os.LookupEnv("CDS_OUTPUT"); ok {
+		return strings.ToLower(env)
+	}
+	return "auto"
+}
+
+func isNoColorSet() bool {
+	_, ok := os.LookupEnv("NO_COLOR")
+	return ok
+}
+
+func isColorable() bool {
+	return isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd())
+}

--- a/internal/output/model_test.go
+++ b/internal/output/model_test.go
@@ -1,0 +1,39 @@
+package output
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFromContextHandlesPointer(t *testing.T) {
+	ctx := WithOutputOptions(context.Background(), &OutputOptions{
+		mode:    ModeJSON,
+		command: "space.host.list",
+	})
+
+	got := FromContext(ctx)
+
+	assert.Equal(t, ModeJSON, got.mode)
+	assert.Equal(t, "space.host.list", got.command)
+}
+
+func TestRenderJSONProducesValidJSON(t *testing.T) {
+	var buf bytes.Buffer
+
+	err := Render(OutputOptions{
+		mode:   ModeJSON,
+		writer: &buf,
+	}, SimpleResult{Message: "hello"})
+	require.NoError(t, err)
+
+	var payload struct {
+		Data SimpleResult `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &payload))
+	assert.Equal(t, "hello", payload.Data.Message)
+}

--- a/internal/output/simple.go
+++ b/internal/output/simple.go
@@ -1,0 +1,12 @@
+package output
+
+// SimpleResult is a single-message result for commands with no complex output.
+type SimpleResult struct {
+	Message string `json:"message"`
+}
+
+func (r SimpleResult) HumanReadable(_ OutputOptions) string {
+	return r.Message + "\n"
+}
+
+func (r SimpleResult) MachineReadable() any { return r }

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -1,0 +1,80 @@
+package output
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pterm/pterm"
+)
+
+// TableResult renders tabular data for list-style commands.
+type TableResult struct {
+	Headers []string   // column headers
+	Rows    [][]string // row data
+	Data    any        // typed slice for JSON serialization
+}
+
+func (t TableResult) HumanReadable(o OutputOptions) string {
+	if len(t.Rows) == 0 {
+		return "No results found.\n"
+	}
+
+	tableData := pterm.TableData{t.Headers}
+	for _, row := range t.Rows {
+		tableData = append(tableData, row)
+	}
+
+	if o.mode == ModePlain {
+		return renderPlainTable(t.Headers, t.Rows)
+	}
+
+	rendered, err := pterm.DefaultTable.
+		WithHasHeader(true).
+		WithData(tableData).
+		WithSeparator("  ").
+		Srender()
+	if err != nil {
+		return renderPlainTable(t.Headers, t.Rows)
+	}
+	return rendered + "\n"
+}
+
+func (t TableResult) MachineReadable() any {
+	return t.Data
+}
+
+// renderPlainTable produces a simple aligned text table without ANSI codes.
+func renderPlainTable(headers []string, rows [][]string) string {
+	colWidths := make([]int, len(headers))
+	for i, h := range headers {
+		colWidths[i] = len(h)
+	}
+	for _, row := range rows {
+		for i, cell := range row {
+			if i < len(colWidths) && len(cell) > colWidths[i] {
+				colWidths[i] = len(cell)
+			}
+		}
+	}
+
+	var sb strings.Builder
+	writePaddedRow(&sb, headers, colWidths)
+	for _, row := range rows {
+		writePaddedRow(&sb, row, colWidths)
+	}
+	return sb.String()
+}
+
+func writePaddedRow(sb *strings.Builder, cells []string, widths []int) {
+	for i, cell := range cells {
+		if i > 0 {
+			sb.WriteString("  ")
+		}
+		if i < len(widths) {
+			fmt.Fprintf(sb, "%-*s", widths[i], cell)
+		} else {
+			sb.WriteString(cell)
+		}
+	}
+	sb.WriteByte('\n')
+}


### PR DESCRIPTION
## Summary

The goal is to avoid filling command package with output formatting logic


## Related issues

- Fixes #
- Closes #
- Relates-to #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / maintenance

## How to test

Provide the commands and steps used to validate this change.

```bash
make test
make lint
```

## Checklist

- [ ] I ran `make test` (or equivalent) and it passed.
- [ ] I ran `make lint` (if applicable) and it passed.
- [ ] I updated docs (README/CONTRIBUTING) if needed.
- [ ] I added or updated tests where appropriate.
- [ ] I linked relevant issues and provided context.

## Notes for reviewers

Anything you want reviewers to pay attention to (risk areas, rollout, follow-ups).
