### PR TITLE
feat(host) detect Podman and register local machine as a DevContainer host

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ Before installing CDS, ensure you have the following dependencies:
   - Linux/macOS: Usually pre-installed
   - Windows: Use [Git Bash](https://git-scm.com/downloads) or [WSL](https://docs.microsoft.com/en-us/windows/wsl/install)
 - **OpenSSL**: For TLS certificate operations (usually pre-installed on Linux/macOS)
+- **Podman**: Container runtime for running DevContainers on a local host ([Installation](https://podman.io/docs/installation)). On macOS, also initialise and start the Podman machine:
+  ```bash
+  podman machine init   # first time only
+  podman machine start
+  ```
 
 ### Optional Tools
 
@@ -169,8 +174,10 @@ cds project init
 # Initialize a new space
 cds space init
 
-# Bootstrap an agent host
-cds space host add
+# Register the local machine as a DevContainer host (detects Podman)
+cds space host add localhost
+
+# Bootstrap a remote agent host
 cds space host add https://agent.example:8443
 
 # Manage configured agent hosts

--- a/internal/bo/host_scaffold.go
+++ b/internal/bo/host_scaffold.go
@@ -24,3 +24,9 @@ type RegistryInfo struct {
 	State string `json:"status"`
 	Port  int    `json:"port"`
 }
+
+// RuntimeInfo describes the container runtime detected on a host.
+type RuntimeInfo struct {
+	Engine  string `json:"engine"`
+	Version string `json:"version"`
+}

--- a/internal/command/space_host_add.go
+++ b/internal/command/space_host_add.go
@@ -7,12 +7,20 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/amadeusitgroup/cds/internal/bo"
 	"github.com/amadeusitgroup/cds/internal/bootstrap"
+	"github.com/amadeusitgroup/cds/internal/cenv"
 	"github.com/amadeusitgroup/cds/internal/cerr"
+	"github.com/amadeusitgroup/cds/internal/containerruntime"
+	"github.com/amadeusitgroup/cds/internal/db"
 	cg "github.com/amadeusitgroup/cds/internal/global"
 	"github.com/amadeusitgroup/cds/internal/output"
 	"github.com/spf13/cobra"
 )
+
+// detectRuntime is the container-runtime detector used during local host
+// registration. It is a package variable so tests can substitute a fake.
+var detectRuntime = containerruntime.Detect
 
 type spcHostAdd struct {
 	defaultCmd
@@ -60,9 +68,22 @@ func (s *spcHostAdd) runE(cmd *cobra.Command, args []string) error {
 		alreadyRunning = true
 	}
 
-	// TODO: Persist or refresh the CLI host entry once bootstrap exposes the resolved endpoint and credentials again.
-	// TODO: Honor the full --target-server value during registration instead of only deriving the bootstrap hostname.
-	// TODO: Reintroduce local port selection once bootstrap accepts launch options directly.
+	// For a local host, detect the container runtime and register the host as a
+	// DevContainer deploy target. Detection failures (no Podman, machine not
+	// running) abort registration with an actionable message. The same predicate
+	// as bootstrap.StartAgent is used so a given target is treated as local by
+	// both the agent launch and the host registration.
+	if isLocalTarget(hostName) {
+		info, err := registerLocalHost(hostName)
+		if err != nil {
+			return err
+		}
+		o := output.FromContext(cmd.Context())
+		return output.Render(o, output.SimpleResult{
+			Message: fmt.Sprintf("Registered local host %q with runtime %s %s",
+				hostName, info.Engine, info.Version),
+		})
+	}
 
 	message := fmt.Sprintf("Bootstrapped host %q", hostName)
 	if alreadyRunning {
@@ -71,6 +92,40 @@ func (s *spcHostAdd) runE(cmd *cobra.Command, args []string) error {
 
 	o := output.FromContext(cmd.Context())
 	return output.Render(o, output.SimpleResult{Message: message})
+}
+
+// isLocalTarget reports whether hostName denotes the local machine, matching the
+// decision bootstrap.StartAgent makes between fire() and fireRemote().
+func isLocalTarget(hostName string) bool {
+	return hostName == cg.KLocalhost
+}
+
+// registerLocalHost detects the local container runtime and records the host in
+// the CLI state as a target for DevContainer deployment. It is idempotent: an
+// existing host entry is updated in place rather than duplicated. It returns the
+// detected runtime so the caller can report what was registered. The persisted
+// state is flushed to disk by the caller (main defers db.Save()).
+func registerLocalHost(hostName string) (containerruntime.Info, error) {
+	// Return the detection error as-is: it already carries an actionable message,
+	// and not wrapping it preserves the typed sentinels (containerruntime.Err*)
+	// so callers can branch with errors.Is.
+	info, err := detectRuntime()
+	if err != nil {
+		return containerruntime.Info{}, err
+	}
+
+	if !db.HasHost(hostName) {
+		db.AddHost(hostName, cenv.GetUsernameFromEnv())
+	}
+
+	if err := db.SetHostRuntime(hostName, bo.RuntimeInfo{
+		Engine:  info.Engine,
+		Version: info.Version,
+	}); err != nil {
+		return containerruntime.Info{}, err
+	}
+
+	return info, nil
 }
 
 func bootstrapHostName(targetServer string) (string, error) {

--- a/internal/command/space_host_add_test.go
+++ b/internal/command/space_host_add_test.go
@@ -1,0 +1,85 @@
+package command
+
+import (
+	"testing"
+
+	"github.com/amadeusitgroup/cds/internal/bo"
+	"github.com/amadeusitgroup/cds/internal/config"
+	"github.com/amadeusitgroup/cds/internal/containerruntime"
+	"github.com/amadeusitgroup/cds/internal/db"
+	cg "github.com/amadeusitgroup/cds/internal/global"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubDetectRuntime replaces the package-level detector for the test's duration.
+func stubDetectRuntime(t *testing.T, info containerruntime.Info, err error) {
+	t.Helper()
+	orig := detectRuntime
+	detectRuntime = func() (containerruntime.Info, error) { return info, err }
+	t.Cleanup(func() { detectRuntime = orig })
+}
+
+// loadEmptyDB initialises an isolated in-memory db backed by the mocked
+// filesystem. ResetForTest clears any store left by a prior test so Load starts
+// from a clean state.
+func loadEmptyDB(t *testing.T) {
+	t.Helper()
+	db.ResetForTest()
+	t.Cleanup(db.ResetForTest)
+	src, err := config.DBSource()
+	require.NoError(t, err)
+	require.NoError(t, db.Load(src))
+}
+
+func TestRegisterLocalHost_Success(t *testing.T) {
+	setupCommandConfigTestFS(t)
+	loadEmptyDB(t)
+	stubDetectRuntime(t, containerruntime.Info{Engine: "podman", Version: "5.2.2"}, nil)
+
+	info, err := registerLocalHost(cg.KLocalhost)
+
+	require.NoError(t, err)
+	assert.Equal(t, "podman", info.Engine)
+	assert.Equal(t, "5.2.2", info.Version)
+	assert.True(t, db.HasHost(cg.KLocalhost))
+	assert.Equal(t, bo.RuntimeInfo{Engine: "podman", Version: "5.2.2"}, db.GetHostRuntime(cg.KLocalhost))
+}
+
+func TestRegisterLocalHost_DetectionFailureRegistersNothing(t *testing.T) {
+	setupCommandConfigTestFS(t)
+	loadEmptyDB(t)
+	stubDetectRuntime(t, containerruntime.Info{}, containerruntime.ErrMachineNotRunning)
+
+	_, err := registerLocalHost(cg.KLocalhost)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, containerruntime.ErrMachineNotRunning)
+	assert.False(t, db.HasHost(cg.KLocalhost), "no host should be registered when detection fails")
+}
+
+func TestRegisterLocalHost_Idempotent(t *testing.T) {
+	setupCommandConfigTestFS(t)
+	loadEmptyDB(t)
+	stubDetectRuntime(t, containerruntime.Info{Engine: "podman", Version: "5.2.2"}, nil)
+
+	_, err := registerLocalHost(cg.KLocalhost)
+	require.NoError(t, err)
+	_, err = registerLocalHost(cg.KLocalhost)
+	require.NoError(t, err)
+
+	hosts := db.ListHostNames()
+	count := 0
+	for _, h := range hosts {
+		if h == cg.KLocalhost {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "re-registering must not duplicate the host")
+}
+
+func TestIsLocalTarget(t *testing.T) {
+	assert.True(t, isLocalTarget(cg.KLocalhost))
+	assert.False(t, isLocalTarget("agent.example"))
+	assert.False(t, isLocalTarget(""))
+}

--- a/internal/containerruntime/containerruntime.go
+++ b/internal/containerruntime/containerruntime.go
@@ -1,0 +1,165 @@
+// Package containerruntime detects and validates the container runtime (Podman)
+// that the agent relies on to manage DevContainers on a host.
+//
+// On macOS, Podman runs inside a virtual machine, so a usable runtime requires
+// more than the binary being on PATH: the Podman machine must also be running
+// and answering. Detect performs those checks and reports an actionable error
+// for each failure mode. On Linux, Podman runs natively and the machine check
+// is skipped.
+package containerruntime
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	stdruntime "runtime"
+	"strings"
+
+	"github.com/amadeusitgroup/cds/internal/clog"
+)
+
+// EnginePodman is the only container engine supported for local hosts today.
+const EnginePodman = "podman"
+
+// Info describes the detected container runtime.
+type Info struct {
+	Engine  string // e.g. "podman"
+	Version string // e.g. "5.1.1"
+}
+
+// Detection failures. Errors are wrapped with %w around these sentinels so
+// callers can branch with errors.Is, while the wrapped message carries an
+// actionable hint suitable for display to the developer.
+var (
+	// ErrRuntimeNotFound indicates the Podman binary is not installed / not on PATH.
+	ErrRuntimeNotFound = errors.New("container runtime not found")
+	// ErrMachineNotRunning indicates Podman is installed but its machine (VM) is not running (macOS).
+	ErrMachineNotRunning = errors.New("container runtime machine is not running")
+	// ErrRuntimeUnavailable indicates Podman is installed and reachable, but is not responding.
+	ErrRuntimeUnavailable = errors.New("container runtime is not responding")
+)
+
+// Injection points so detection can be unit-tested without a real Podman and
+// for either operating system.
+var (
+	lookPath   = exec.LookPath
+	runCommand = defaultRunCommand
+	goos       = stdruntime.GOOS
+)
+
+// defaultRunCommand runs a binary directly (no shell) and returns its stdout.
+// stderr is folded into the returned error so callers get useful context.
+func defaultRunCommand(name string, args ...string) (string, error) {
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if stderr.Len() > 0 {
+			return stdout.String(), fmt.Errorf("%w: %s", err, strings.TrimSpace(stderr.String()))
+		}
+		return stdout.String(), err
+	}
+	return stdout.String(), nil
+}
+
+type podmanMachine struct {
+	Name    string `json:"Name"`
+	Running bool   `json:"Running"`
+}
+
+type podmanInfo struct {
+	Version struct {
+		Version string `json:"Version"`
+	} `json:"version"`
+}
+
+// Detect locates the container runtime and validates that it is usable.
+//
+// It returns ErrRuntimeNotFound, ErrMachineNotRunning, or ErrRuntimeUnavailable
+// (wrapped with an actionable message) when the runtime cannot be used.
+func Detect() (Info, error) {
+	clog.Debug("Detecting container runtime (podman)")
+
+	if _, err := lookPath(EnginePodman); err != nil {
+		return Info{}, fmt.Errorf(
+			"%w: install Podman (e.g. `brew install podman`) and run `podman machine init`",
+			ErrRuntimeNotFound)
+	}
+
+	// On VM-backed platforms (macOS, and Windows via WSL2) Podman runs inside a
+	// machine that must be started before it can serve requests. On Linux it runs
+	// natively, so there is no machine to check.
+	if podmanUsesMachine(goos) {
+		running, err := podmanMachineRunning()
+		if err != nil {
+			return Info{}, err
+		}
+		if !running {
+			return Info{}, fmt.Errorf(
+				"%w: start it with `podman machine start` (initialise first with `podman machine init` if needed)",
+				ErrMachineNotRunning)
+		}
+	}
+
+	version, err := podmanVersion()
+	if err != nil {
+		return Info{}, fmt.Errorf(
+			"%w: `podman info` failed (%v)", ErrRuntimeUnavailable, err)
+	}
+
+	info := Info{Engine: EnginePodman, Version: version}
+	clog.Debug(fmt.Sprintf("Detected %s %s", info.Engine, info.Version))
+	return info, nil
+}
+
+// podmanUsesMachine reports whether Podman runs inside a managed VM ("machine")
+// on the given OS rather than natively. macOS (applehv) and Windows (WSL2) are
+// VM-backed and require `podman machine start`; Linux runs natively.
+//
+// Windows is listed here for correctness, but Windows host registration is not
+// yet wired up — see the local-host-registration design doc (out of scope).
+func podmanUsesMachine(os string) bool {
+	return os == "darwin" || os == "windows"
+}
+
+// podmanMachineRunning reports whether at least one Podman machine is running.
+func podmanMachineRunning() (bool, error) {
+	out, err := runCommand(EnginePodman, "machine", "list", "--format", "json")
+	if err != nil {
+		return false, fmt.Errorf("%w: `podman machine list` failed (%v)", ErrMachineNotRunning, err)
+	}
+
+	out = strings.TrimSpace(out)
+	if out == "" || out == "[]" {
+		return false, nil
+	}
+
+	var machines []podmanMachine
+	if err := json.Unmarshal([]byte(out), &machines); err != nil {
+		return false, fmt.Errorf("%w: failed to parse `podman machine list` output (%v)", ErrMachineNotRunning, err)
+	}
+
+	for _, m := range machines {
+		if m.Running {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// podmanVersion returns the Podman version reported by `podman info`.
+func podmanVersion() (string, error) {
+	out, err := runCommand(EnginePodman, "info", "--format", "json")
+	if err != nil {
+		return "", err
+	}
+
+	var info podmanInfo
+	if err := json.Unmarshal([]byte(out), &info); err != nil {
+		return "", fmt.Errorf("failed to parse `podman info` output: %w", err)
+	}
+	return info.Version.Version, nil
+}

--- a/internal/containerruntime/containerruntime_test.go
+++ b/internal/containerruntime/containerruntime_test.go
@@ -1,0 +1,174 @@
+package containerruntime
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// withStubs swaps the injected lookPath/runCommand/goos for the duration of a
+// test and restores them afterwards.
+func withStubs(t *testing.T, os string, lp func(string) (string, error), rc func(string, ...string) (string, error)) {
+	t.Helper()
+	origLookPath, origRun, origGoos := lookPath, runCommand, goos
+	lookPath, runCommand, goos = lp, rc, os
+	t.Cleanup(func() {
+		lookPath, runCommand, goos = origLookPath, origRun, origGoos
+	})
+}
+
+func TestDetect_RuntimeNotFound(t *testing.T) {
+	withStubs(t, "darwin",
+		func(string) (string, error) { return "", errors.New("not found") },
+		func(string, ...string) (string, error) {
+			t.Fatal("runCommand should not be called when the binary is missing")
+			return "", nil
+		},
+	)
+
+	_, err := Detect()
+	assert.ErrorIs(t, err, ErrRuntimeNotFound)
+}
+
+func TestDetect_MachineNotRunning_Darwin(t *testing.T) {
+	tests := []struct {
+		name       string
+		listOutput string
+	}{
+		{name: "empty output", listOutput: ""},
+		{name: "empty array", listOutput: "[]"},
+		{name: "machine stopped", listOutput: `[{"Name":"podman-machine-default","Running":false}]`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withStubs(t, "darwin",
+				func(string) (string, error) { return "/usr/bin/podman", nil },
+				func(_ string, args ...string) (string, error) {
+					assert.Equal(t, []string{"machine", "list", "--format", "json"}, args)
+					return tt.listOutput, nil
+				},
+			)
+
+			_, err := Detect()
+			assert.ErrorIs(t, err, ErrMachineNotRunning)
+		})
+	}
+}
+
+func TestDetect_MachineListFails_Darwin(t *testing.T) {
+	withStubs(t, "darwin",
+		func(string) (string, error) { return "/usr/bin/podman", nil },
+		func(string, ...string) (string, error) { return "", errors.New("connection refused") },
+	)
+
+	_, err := Detect()
+	assert.ErrorIs(t, err, ErrMachineNotRunning)
+}
+
+func TestDetect_RuntimeUnavailable_Darwin(t *testing.T) {
+	withStubs(t, "darwin",
+		func(string) (string, error) { return "/usr/bin/podman", nil },
+		func(_ string, args ...string) (string, error) {
+			if args[0] == "machine" {
+				return `[{"Name":"podman-machine-default","Running":true}]`, nil
+			}
+			return "", errors.New("cannot connect to Podman socket")
+		},
+	)
+
+	_, err := Detect()
+	assert.ErrorIs(t, err, ErrRuntimeUnavailable)
+}
+
+func TestDetect_Healthy_Darwin(t *testing.T) {
+	withStubs(t, "darwin",
+		func(string) (string, error) { return "/usr/bin/podman", nil },
+		func(_ string, args ...string) (string, error) {
+			switch args[0] {
+			case "machine":
+				return `[{"Name":"podman-machine-default","Running":true}]`, nil
+			case "info":
+				return `{"version":{"Version":"5.1.1"}}`, nil
+			default:
+				t.Fatalf("unexpected podman subcommand: %v", args)
+				return "", nil
+			}
+		},
+	)
+
+	info, err := Detect()
+	assert.NoError(t, err)
+	assert.Equal(t, EnginePodman, info.Engine)
+	assert.Equal(t, "5.1.1", info.Version)
+}
+
+func TestDetect_Healthy_DarwinMultipleMachines(t *testing.T) {
+	withStubs(t, "darwin",
+		func(string) (string, error) { return "/usr/bin/podman", nil },
+		func(_ string, args ...string) (string, error) {
+			switch args[0] {
+			case "machine":
+				return `[{"Name":"stopped","Running":false},{"Name":"default","Running":true}]`, nil
+			case "info":
+				return `{"version":{"Version":"5.2.0"}}`, nil
+			default:
+				return "", nil
+			}
+		},
+	)
+
+	info, err := Detect()
+	assert.NoError(t, err)
+	assert.Equal(t, "5.2.0", info.Version)
+}
+
+// On Linux, Podman runs natively: there is no machine, so `podman machine list`
+// must never be called and detection succeeds straight from `podman info`.
+func TestDetect_Healthy_LinuxSkipsMachineCheck(t *testing.T) {
+	withStubs(t, "linux",
+		func(string) (string, error) { return "/usr/bin/podman", nil },
+		func(_ string, args ...string) (string, error) {
+			if args[0] == "machine" {
+				t.Fatal("podman machine list must not be called on Linux")
+			}
+			return `{"version":{"Version":"4.9.0"}}`, nil
+		},
+	)
+
+	info, err := Detect()
+	assert.NoError(t, err)
+	assert.Equal(t, "4.9.0", info.Version)
+}
+
+func TestDetect_RuntimeUnavailable_Linux(t *testing.T) {
+	withStubs(t, "linux",
+		func(string) (string, error) { return "/usr/bin/podman", nil },
+		func(string, ...string) (string, error) { return "", errors.New("cannot connect to Podman socket") },
+	)
+
+	_, err := Detect()
+	assert.ErrorIs(t, err, ErrRuntimeUnavailable)
+}
+
+// Windows, like macOS, runs Podman in a VM, so the machine check must apply: a
+// stopped machine reports ErrMachineNotRunning, not ErrRuntimeUnavailable.
+func TestDetect_MachineNotRunning_Windows(t *testing.T) {
+	withStubs(t, "windows",
+		func(string) (string, error) { return `C:\podman\podman.exe`, nil },
+		func(_ string, args ...string) (string, error) {
+			assert.Equal(t, "machine", args[0])
+			return "[]", nil
+		},
+	)
+
+	_, err := Detect()
+	assert.ErrorIs(t, err, ErrMachineNotRunning)
+}
+
+func TestPodmanUsesMachine(t *testing.T) {
+	assert.True(t, podmanUsesMachine("darwin"))
+	assert.True(t, podmanUsesMachine("windows"))
+	assert.False(t, podmanUsesMachine("linux"))
+}

--- a/internal/db/bom.go
+++ b/internal/db/bom.go
@@ -42,8 +42,6 @@ type context struct {
 	ProjectContext string `json:"project"`
 }
 
-
-
 // //////////////////////////////////////////////////////////////////
 //
 //	Project Struct
@@ -111,7 +109,14 @@ type host struct {
 	InUse             bool              `json:"inUse"`
 	IsDefault         bool              `json:"default"`
 	OrchestrationInfo orchestrationInfo `json:"orchestrationInfo"`
+	RuntimeInfo       runtimeInfo       `json:"runtimeInfo,omitempty,omitzero"`
 	sshInfo
+}
+
+// runtimeInfo records the container runtime detected on the host.
+type runtimeInfo struct {
+	Engine  string `json:"engine,omitempty,omitzero"`
+	Version string `json:"version,omitempty,omitzero"`
 }
 
 type orchestrationInfo struct {

--- a/internal/db/host.go
+++ b/internal/db/host.go
@@ -263,3 +263,30 @@ func GetRegistryInfoFromHost(hostName string) bo.RegistryInfo {
 	}
 	return value.(bo.RegistryInfo)
 }
+
+func SetHostRuntime(hostName string, info bo.RuntimeInfo) error {
+	var fn decorateHost = func(h *host) {
+		h.RuntimeInfo = runtimeInfo{
+			Engine:  info.Engine,
+			Version: info.Version,
+		}
+	}
+	if err := fn.update(hostName); err != nil {
+		return cerr.AppendErrorFmt("Failed to update runtime info for host %s", err, hostName)
+	}
+	return nil
+}
+
+func GetHostRuntime(hostName string) bo.RuntimeInfo {
+	var fn visitHost = func(h *host) any {
+		return bo.RuntimeInfo{
+			Engine:  h.RuntimeInfo.Engine,
+			Version: h.RuntimeInfo.Version,
+		}
+	}
+	value, err := fn.get(hostName)
+	if err != nil {
+		return bo.RuntimeInfo{}
+	}
+	return value.(bo.RuntimeInfo)
+}

--- a/internal/db/host_registration_test.go
+++ b/internal/db/host_registration_test.go
@@ -1,0 +1,66 @@
+package db
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/amadeusitgroup/cds/internal/bo"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetAndGetHostRuntime(t *testing.T) {
+	tests := []struct {
+		name         string
+		initialData  data
+		hostToUpdate string
+		info         bo.RuntimeInfo
+		expectError  bool
+	}{
+		{
+			name:         "Set runtime info for existing host",
+			initialData:  data{hosts: hosts{Hosts: []*host{{Name: "localhost"}, {Name: "host2"}}}},
+			hostToUpdate: "localhost",
+			info:         bo.RuntimeInfo{Engine: "podman", Version: "5.1.1"},
+			expectError:  false,
+		},
+		{
+			name:         "Set runtime info for non-existing host",
+			initialData:  data{hosts: hosts{Hosts: []*host{{Name: "localhost"}}}},
+			hostToUpdate: "missing",
+			info:         bo.RuntimeInfo{Engine: "podman", Version: "5.1.1"},
+			expectError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tearDown := setupTest(t, tt.initialData)
+			defer tearDown()
+
+			err := SetHostRuntime(tt.hostToUpdate, tt.info)
+			if tt.expectError {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.info, GetHostRuntime(tt.hostToUpdate))
+		})
+	}
+}
+
+// TestHostRuntimeBackwardCompatible ensures a db.json written before the
+// runtimeInfo field existed still loads, with the new field zero-valued.
+func TestHostRuntimeBackwardCompatible(t *testing.T) {
+	legacy := `{"hosts":[{"name":"localhost","username":"dev"}]}`
+
+	var d data
+	err := json.Unmarshal([]byte(legacy), &d)
+	assert.NoError(t, err)
+
+	tearDown := setupTest(t, d)
+	defer tearDown()
+
+	assert.True(t, HasHost("localhost"))
+	assert.Equal(t, bo.RuntimeInfo{}, GetHostRuntime("localhost"))
+}

--- a/internal/db/instance.go
+++ b/internal/db/instance.go
@@ -61,6 +61,13 @@ func resetContent() {
 	dbSrc = nil
 }
 
+// ResetForTest clears the in-memory store so a subsequent Load re-reads from its
+// source. Intended for tests in other packages that need an isolated db between
+// runs; it is a no-op concern in production where the store is loaded once.
+func ResetForTest() {
+	resetContent()
+}
+
 func getDBContent() (*store, error) {
 	if sStore == nil {
 		sStore = newDB()


### PR DESCRIPTION
Implements localhost DevContainer support: `cds space host add localhost`
now detects the container runtime (Podman) and registers the local machine in
CLI state as a target for DevContainer deployment.

This is the prerequisite for `xcds init` / `xcds run` — without a registered
host, the agent has no target to deploy containers to.

## Why

There was previously **no container-runtime detection anywhere** in the codebase
(the engine blindly defaulted to Podman) and **no notion of a local host as a
deploy target**. This PR adds both, scoped tightly to registration.

## What it does

Running `cds space host add localhost`:
1. Detects Podman — binary on PATH → Podman machine running (macOS/Windows run
   it in a VM) → version via `podman info`.
2. Fails with an actionable message if the runtime isn't ready
   (install Podman / `podman machine start` / not responding).
3. Registers `localhost` in `~/.xcds/db.json` with the detected `{engine, version}`.
   Idempotent — re-running updates in place, never duplicates.
4. Reports: `Registered local host "localhost" with runtime podman 5.2.2`.

## Changes

- **New `internal/containerruntime` package** — `Detect()` with typed errors
  (`ErrRuntimeNotFound`, `ErrMachineNotRunning`, `ErrRuntimeUnavailable`). The
  Podman-machine check is gated to VM-backed platforms (macOS/Windows); Linux
  runs natively and skips it. `lookPath`/`runCommand`/`goos` are injected so the
  full OS matrix is unit-tested without a real Podman.
- **Host model** (`internal/db`, `internal/bo`) — added `runtimeInfo` to the host
  record + `Set/GetHostRuntime` accessors (following the existing `SetOrcInfo*`
  pattern). Additive `omitempty,omitzero` tags keep existing `db.json` loading.
- **`space host add`** — detects + registers on local hosts, gated on the same
  predicate `bootstrap.StartAgent` uses. Retires the host-registration TODOs.
- **`db.ResetForTest`** — cross-package test isolation helper.
- **README** — documents the command and the Podman prerequisite.

## Relationship to `feat/agent-services`

This branch was built **fresh against `main`**, using @1atsavignac 's exploratory
`feat/agent-services` branch purely as a **reference design** — not as a base. No
code was ported from it (that branch is unmerged, has a WIP commit, and conflicts
with `main`'s merged systemd work + changes the TLS-path API from a variable to a
function).

What I took as *inspiration / patterns* from `feat/agent-services`:
- The `omitempty,omitzero` JSON-tag convention for backward-compatible additive
  state on the db model.
- The injected-exec-var idiom (`lookPath`/`runCommand` as package vars) for
  testing detection without real binaries.
- The host-keyed-upsert mindset (idempotent registration).

Notably, the two core pieces here — **Podman detection** and the **host
`runtimeInfo` field** — do **not** exist on `feat/agent-services` either; they are
net-new. The larger machinery on that branch (gRPC `ContainerService`, the deploy
spine) is the reference for the future **M4** deploy step, not used here.

**Merge coordination:** this PR overlaps with `feat/agent-services` in
`db/bom.go`, `db/host.go`, `command/space_host_add.go`, and `bo/host_scaffold.go`.
When that branch lands there will be conflicts.

## Testing

- `internal/containerruntime`: detection table tests across darwin / linux /
  windows × {missing, machine-stopped, list-fails, unresponsive, healthy}.
- `internal/db`: `Set/GetHostRuntime` round-trip + legacy-`db.json` back-compat.
- `internal/command`: `registerLocalHost` success, registers-nothing-on-failure
  (asserts the typed sentinel survives via `errors.Is`), and idempotency.
- Manually verified on macOS with Podman 5.2.2.

